### PR TITLE
Add FAN_TRAY and POWER_TRAY component types.

### DIFF
--- a/release/models/platform/openconfig-platform-types.yang
+++ b/release/models/platform/openconfig-platform-types.yang
@@ -22,7 +22,13 @@ module openconfig-platform-types {
     "This module defines data types (e.g., YANG identities)
     to support the OpenConfig component inventory model.";
 
-  oc-ext:openconfig-version "1.6.0";
+  oc-ext:openconfig-version "1.7.0";
+
+  revision "2024-04-12" {
+    description
+      "Add FAN_TRAY and POWER_TRAY";
+    reference "1.7.0";
+  }
 
   revision "2023-06-27" {
     description
@@ -286,10 +292,22 @@ module openconfig-platform-types {
       "Component that is supplying power to the device";
   }
 
+  identity POWER_TRAY {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "The physical housing that holds the power modules (or power supply units) and connects them to the chassis.";
+  }
+
   identity FAN {
     base OPENCONFIG_HARDWARE_COMPONENT;
     description
       "Cooling fan, or could be some other heat-reduction component";
+  }
+
+  identity FAN_TRAY {
+    base OPENCONFIG_HARDWARE_COMPONENT;
+    description
+      "Contains multiple fans that work in unison to cool the router components.";
   }
 
   identity SENSOR {


### PR DESCRIPTION
### Change Scope

* [Please briefly describe the change that is being made to the models.]
  * Adding two new types for hardware components: POWER_TRAY and FAN_TRAY. These are seen on vendor devices such as Arista, Cisco, and Juniper. Right now these components have type FRU, but this is not specific enough to classify the components using their type.
* [Please indicate whether this change is backwards compatible.]
  * Yes this is backwards compatible.
### Platform Implementations

 * Implementation A: [link to documentation](http://foo.com) and/or
   implementation output.
 * Implementation B: [link to documentation](http://foo.com) and/or
   implementation output.

[Note: Please provide at least two references to implementations which are relevant to the model changes proposed.  Each implementation should be from separate organizations.]. 

[Note: If the feature being proposed is new - and something that is being
proposed as an enhancement to device functionality, it is sufficient to have
reviewers from the producers of two different implementations].
